### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ you can download dictionaries for your language from [LibreOffice][3].
 
 [3]: http://cgit.freedesktop.org/libreoffice/dictionaries/tree/
 
+Spelling requires that the environmental variable LANG be set.
+For example EN-US.
+
 Spelling provides commands to turn spell checking on and off on the
 current editor.  By default, the language set in your environmental
 variables is used, but the "Set language" command will change the


### PR DESCRIPTION
The LANG variable is **not** set on Windows. The plugin fails to initialize. The following message shows up in the console:

```
TypeError: Cannot call method 'split' of undefined
    at eval (C:\Users\me\AppData\Local\LightTable\plugins\Spelling\spelling_compiled.js:15:84)
```
